### PR TITLE
Add check if filesystem exists before re-formatting

### DIFF
--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -119,8 +119,7 @@ func formateAndMakeFS(device string, fstype string) error {
 	// Only format if no filesystem exists
 	mkfsCmd := fmt.Sprintf("mkfs.%s", fstype)
 
-	_, err := exec.LookPath(mkfsCmd)
-	if err != nil {
+	if _, err := exec.LookPath(mkfsCmd); err != nil {
 		return fmt.Errorf("unable to find the mkfs (%s) utiltiy errors is %s", mkfsCmd, err.Error())
 	}
 


### PR DESCRIPTION
Ran into an issue where PV's were being wiped on mount to either new nodes (or the same node). Issue is during NodeStageVolume, we call into formatAndMakeFS - It runs a mkfs command on the FS, which formats and wipes the data (regardless of if there's already an existing FS there). 

Added a check for filesystem existence before re-creating.