### PR TITLE
Fix race conditions on unmount, and verify volume is actually attached to the correct node

### DIFF
--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -343,7 +343,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		}
 		return nil, status.Error(codes.DeadlineExceeded, "ControllerUnpublishVolume: Timeout waiting for volume to detach")
 	}
-	return nil, status.Errorf(codes.Internal, "ControllerPublishVolume: Volume in unexpected state: %s", *getVolume.Status)
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -340,7 +340,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		}
 		return nil, status.Error(codes.DeadlineExceeded, "ControllerUnpublishVolume: Timeout waiting for volume to detach")
 	}
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
+	return nil, status.Errorf(codes.Internal, "ControllerPublishVolume: Volume in unexpected state: %s", *getVolume.Status)
 }
 
 func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -280,7 +280,10 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		}
 		return nil, status.Error(codes.DeadlineExceeded, "ControllerPublishVolume: Timeout waiting for attachment to complete")
 	}
-	return &csi.ControllerPublishVolumeResponse{}, nil
+
+	klog.Errorf("ControllerPublishVolume: Volume %s in unexpected state: %s", *getVolume.Name, *getVolume.Status)
+	return nil, status.Errorf(codes.FailedPrecondition,
+		"Volume in unexpected state: %s (expected 'available' or 'in-use')", *getVolume.Status)
 }
 
 func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {


### PR DESCRIPTION
Right now, there isn't any polling on volume unpublished, or any verification that a disk is actually attached to the correct node in the volume publish. Adding both checks here to avoid mounting in another containers volume. Could be missing the mark here on root cause - this is a WIP as I test this on our staging cluster