### PR TITLE
feat: support VOLUME_MOUNT_GROUP for non-root pod volume access

### DIFF
--- a/charts/csi-hyperstack/templates/csi.yaml
+++ b/charts/csi-hyperstack/templates/csi.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   volumeLifecycleModes:
     - Persistent
-  fsGroupPolicy: None
+  fsGroupPolicy: File

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -92,6 +92,7 @@ func NewDriver(opts *DriverOpts) *Driver {
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 	})
 
 	d.vcap = MapVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,6 +55,25 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, err
 	}
+
+	// Apply fsGroup ownership if provided via VOLUME_MOUNT_GROUP capability.
+	// Sets group on the root inode so non-root pods with matching fsGroup can write.
+	if mountVolume := req.VolumeCapability.GetMount(); mountVolume != nil {
+		if volumeMountGroup := mountVolume.GetVolumeMountGroup(); volumeMountGroup != "" {
+			gid, err := strconv.Atoi(volumeMountGroup)
+			if err != nil {
+				return nil, fmt.Errorf("invalid volume_mount_group %q: %w", volumeMountGroup, err)
+			}
+			if err := os.Chown(target, -1, gid); err != nil {
+				return nil, fmt.Errorf("failed to chown staging path %s to gid %d: %w", target, gid, err)
+			}
+			if err := os.Chmod(target, 0775); err != nil {
+				return nil, fmt.Errorf("failed to chmod staging path %s: %w", target, err)
+			}
+			klog.Infof("NodeStageVolume: set group %d and mode 0775 on %s", gid, target)
+		}
+	}
+
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
@@ -210,6 +230,25 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	source := req.StagingTargetPath
 	target := req.TargetPath
+
+	// Apply fsGroup ownership on the staging path before bind-mounting.
+	// This runs on every publish so permissions are correct even if the volume
+	// was staged before the driver was upgraded.
+	if mountVolume := req.VolumeCapability.GetMount(); mountVolume != nil {
+		if volumeMountGroup := mountVolume.GetVolumeMountGroup(); volumeMountGroup != "" {
+			gid, err := strconv.Atoi(volumeMountGroup)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "invalid volume_mount_group %q: %v", volumeMountGroup, err)
+			}
+			if err := os.Chown(source, -1, gid); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to chown staging path %s to gid %d: %v", source, gid, err)
+			}
+			if err := os.Chmod(source, 0775); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to chmod staging path %s: %v", source, err)
+			}
+			klog.Infof("NodePublishVolume: set group %d and mode 0775 on %s", gid, source)
+		}
+	}
 
 	err = mountDevice(source, target, fsType, options)
 	if err != nil {

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -67,10 +67,10 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			if err := os.Chown(target, -1, gid); err != nil {
 				return nil, fmt.Errorf("failed to chown staging path %s to gid %d: %w", target, gid, err)
 			}
-			if err := os.Chmod(target, 0775); err != nil {
+			if err := os.Chmod(target, 0775|os.ModeSetgid); err != nil {
 				return nil, fmt.Errorf("failed to chmod staging path %s: %w", target, err)
 			}
-			klog.Infof("NodeStageVolume: set group %d and mode 0775 on %s", gid, target)
+			klog.Infof("NodeStageVolume: set group %d and mode 02775 (setgid) on %s", gid, target)
 		}
 	}
 
@@ -243,10 +243,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			if err := os.Chown(source, -1, gid); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to chown staging path %s to gid %d: %v", source, gid, err)
 			}
-			if err := os.Chmod(source, 0775); err != nil {
+			if err := os.Chmod(source, 0775|os.ModeSetgid); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to chmod staging path %s: %v", source, err)
 			}
-			klog.Infof("NodePublishVolume: set group %d and mode 0775 on %s", gid, source)
+			klog.Infof("NodePublishVolume: set group %d and mode 02775 (setgid) on %s", gid, source)
 		}
 	}
 

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -62,13 +62,13 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		if volumeMountGroup := mountVolume.GetVolumeMountGroup(); volumeMountGroup != "" {
 			gid, err := strconv.Atoi(volumeMountGroup)
 			if err != nil {
-				return nil, fmt.Errorf("invalid volume_mount_group %q: %w", volumeMountGroup, err)
+				return nil, status.Errorf(codes.InvalidArgument, "invalid volume_mount_group %q: %v", volumeMountGroup, err)
 			}
 			if err := os.Chown(target, -1, gid); err != nil {
-				return nil, fmt.Errorf("failed to chown staging path %s to gid %d: %w", target, gid, err)
+				return nil, status.Errorf(codes.Internal, "failed to chown staging path %s to gid %d: %v", target, gid, err)
 			}
 			if err := os.Chmod(target, 0775|os.ModeSetgid); err != nil {
-				return nil, fmt.Errorf("failed to chmod staging path %s: %w", target, err)
+				return nil, status.Errorf(codes.Internal, "failed to chmod staging path %s: %v", target, err)
 			}
 			klog.Infof("NodeStageVolume: set group %d and mode 02775 (setgid) on %s", gid, target)
 		}
@@ -238,7 +238,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if volumeMountGroup := mountVolume.GetVolumeMountGroup(); volumeMountGroup != "" {
 			gid, err := strconv.Atoi(volumeMountGroup)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "invalid volume_mount_group %q: %v", volumeMountGroup, err)
+				return nil, status.Errorf(codes.InvalidArgument, "invalid volume_mount_group %q: %v", volumeMountGroup, err)
 			}
 			if err := os.Chown(source, -1, gid); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to chown staging path %s to gid %d: %v", source, gid, err)


### PR DESCRIPTION
### Overview

mkfs.ext4 creates the filesystem root as root:root 0755, blocking writes from non-root pods. Instead of a blanket chmod 0777, implement proper CSI VOLUME_MOUNT_GROUP support so kubelet passes the pod's fsGroup to the driver.

- Advertise VOLUME_MOUNT_GROUP node capability
- Set fsGroupPolicy to File so kubelet delegates to the driver
- Apply chown/chmod 0775 with setgid in both NodeStageVolume and NodePublishVolume using the volume_mount_group from the request
- NodePublishVolume handles it too so volumes staged before the upgrade also get correct permissions without needing PVC recreation
- Use `os.ModeSetgid` (not octal `02775`) so new subdirectories created by kubelet for `subPath` mounts inherit the fsGroup automatically

### Testing

Setup: Deployed Mimir via Helm on a test cluster with PVCs backed by csi-hyperstack StorageClass. Mimir pods run as non-root (runAsUser: 1001, fsGroup: 1001).

Reproducing the issue:
- With the upstream image, pods with CSI-backed PVCs (mimir-compactor, mimir-kafka, mimir-ingester, mimir-store-gateway) all entered CrashLoopBackOff
- Kafka logs confirmed: java.nio.file.AccessDeniedException: /var/lib/kafka/data
- Root cause: mkfs.ext4 creates the filesystem root as root:root 0755, blocking writes from non-root pods

Testing the fix:
1. Upgraded the Helm release with the new CSI driver image
2. Verified CSIDriver object updated to fsGroupPolicy: File via kubectl get csidriver hyperstack.csi.nexgencloud.com -o yaml
3. Verified VOLUME_MOUNT_GROUP capability (type 6) advertised via NodeGetCapabilities in driver logs
4. Deleted and recreated mimir-compactor-0 - pod started successfully (previously CrashLoopBackOff)
5. Confirmed in CSI node logs that NodePublishVolume received volume_mount_group: "10001" and applied chown/chmod 02775 (setgid) on the staging path
6. Verified this works on already-staged volumes - no PVC deletion or volume re-creation required, making this a non-breaking upgrade
7. Verified fix for subPath mounts (e.g. Prometheus with fsGroup: 2000 and subPath: prometheus-db) — pod started successfully after previously failing with permission denied
