### PR TITLE
fix: bump chart to 0.0.9 and skip existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/csi-hyperstack/Chart.yaml
+++ b/charts/csi-hyperstack/Chart.yaml
@@ -3,5 +3,5 @@ name: csi-hyperstack
 description: |
   HELM chart for Hyperstack CSI drvier deployment
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: v0.0.6


### PR DESCRIPTION
- Bump Helm chart version 0.0.8 > 0.0.9 so chart-releaser can publish unreleased changes (metrics, Grafana dashboard, fsGroup support)
- Add `skip_existing: true` to the release workflow to avoid CI failures when a release tag already exists