### PR TITLE
fix: panic when updating volume with no active attachments

### DIFF
--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -204,22 +204,21 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	klog.Infof("ControllerPublishVolume: GetVolume succeeded -\nStatus: %s\nName: %s\nID: %d\nSize:%d", *getVolume.Status, *getVolume.Name, *getVolume.Id, *getVolume.Size)
 	if *getVolume.Status == "in-use" {
 		klog.Infof("ControllerPublishVolume: Volume %s is already in use", *getVolume.Name)
-		if len(*getVolume.Attachments) > 0 {
-			attachedInstanceId := *(*getVolume.Attachments)[0].InstanceId
-			if err != nil {
-				klog.Errorf("ControllerPublishVolume: Failed to convert attached instance ID to int: %v", err)
-				return nil, status.Errorf(codes.Internal, "Failed to convert attached instance ID to int: %v", err)
-			}
-			klog.Infof("ControllerPublishVolume: Volume %s is already attached to node %d", *getVolume.Name, attachedInstanceId)
-			if attachedInstanceId == vmId {
-				return &csi.ControllerPublishVolumeResponse{
-					PublishContext: map[string]string{
-						volNameKeyFromControllerPublishVolume: *(*getVolume.Attachments)[0].Device,
-					},
-				}, nil
-			}
-			klog.Infof("ControllerPublishVolume: Volume attached to wrong node (attached: %d, requested: %d), detaching", attachedInstanceId, vmId)
-			_, err = cloud.DetachVolumeFromNode(ctx, attachedInstanceId, volumeIDInt)
+		if a := findVolumeAttachment(getVolume.Attachments, vmId); a != nil {
+			// Already attached to the requested node — idempotent success.
+			klog.Infof("ControllerPublishVolume: Volume %s is already attached to node %d", *getVolume.Name, vmId)
+			return &csi.ControllerPublishVolumeResponse{
+				PublishContext: map[string]string{
+					volNameKeyFromControllerPublishVolume: *a.Device,
+				},
+			}, nil
+		}
+		// Attached to a different node — detach it first.
+		if getVolume.Attachments != nil && len(*getVolume.Attachments) > 0 {
+			wrongAttachment := (*getVolume.Attachments)[0]
+			wrongInstanceId := *wrongAttachment.InstanceId
+			klog.Infof("ControllerPublishVolume: Volume attached to wrong node (attached: %d, requested: %d), detaching", wrongInstanceId, vmId)
+			_, err = cloud.DetachVolumeFromNode(ctx, wrongInstanceId, volumeIDInt)
 			if err != nil {
 				klog.Errorf("ControllerPublishVolume: Failed to detach from wrong node: %v", err)
 				return nil, status.Errorf(codes.Internal, "ControllerPublishVolume: Failed to detach from wrong node: %v", err)
@@ -316,6 +315,13 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 	klog.Infof("ControllerUnpublishVolume: GetVolume succeeded -\nStatus: %s\nName: %s\nID: %d\nSize:%d", *getVolume.Status, *getVolume.Name, *getVolume.Id, *getVolume.Size)
 	if *getVolume.Status == "in-use" {
+		// CSI spec: if the volume is not attached to this specific node, return
+		// success — the unpublish is already satisfied (idempotent).
+		if findVolumeAttachment(getVolume.Attachments, vmId) == nil {
+			klog.Infof("ControllerUnpublishVolume: volume %d has no attachment to node %d, treating as already detached", volumeIDInt, vmId)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+
 		detachVolume, err := cloud.DetachVolumeFromNode(ctx, vmId, volumeIDInt)
 		if err != nil {
 			klog.Errorf("ControllerUnpublishVolume: Failed to DetachVolumeFromNode: %v", err)

--- a/pkg/driver/helpers.go
+++ b/pkg/driver/helpers.go
@@ -1,0 +1,18 @@
+package driver
+
+import "github.com/NexGenCloud/hyperstack-sdk-go/lib/volume"
+
+// findVolumeAttachment returns the first attachment record whose InstanceId
+// matches instanceID, or nil if no match is found.
+func findVolumeAttachment(attachments *[]volume.AttachmentsFieldsForVolume, instanceID int) *volume.AttachmentsFieldsForVolume {
+	if attachments == nil {
+		return nil
+	}
+	for i := range *attachments {
+		a := &(*attachments)[i]
+		if a.InstanceId != nil && *a.InstanceId == instanceID {
+			return a
+		}
+	}
+	return nil
+}

--- a/pkg/hyperstack/hyperstack_volume.go
+++ b/pkg/hyperstack/hyperstack_volume.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/context"
 	"k8s.io/csi-hyperstack/pkg/metrics"
+	"k8s.io/klog/v2"
 )
 
 var volumeDescription = "Created by Hyperstack CSI driver"
@@ -266,8 +267,9 @@ func (hs *Hyperstack) UpdateVolumeAttachment(ctx context.Context, volumeId int) 
 		return nil, err
 	}
 
-	if len(*getVolume.Attachments) == 0 {
-		return nil, fmt.Errorf("volume %d has no attachments to update", volumeId)
+	if getVolume.Attachments == nil || len(*getVolume.Attachments) == 0 {
+		klog.Infof("UpdateVolumeAttachment: volume %d has no active attachments, skipping", volumeId)
+		return nil, nil
 	}
 
 	var volumeAttachmentID = *(*getVolume.Attachments)[0].Id

--- a/pkg/hyperstack/hyperstack_volume.go
+++ b/pkg/hyperstack/hyperstack_volume.go
@@ -266,6 +266,10 @@ func (hs *Hyperstack) UpdateVolumeAttachment(ctx context.Context, volumeId int) 
 		return nil, err
 	}
 
+	if len(*getVolume.Attachments) == 0 {
+		return nil, fmt.Errorf("volume %d has no attachments to update", volumeId)
+	}
+
 	var volumeAttachmentID = *(*getVolume.Attachments)[0].Id
 
 	var protected = false


### PR DESCRIPTION
The CSI controller crashes with `panic: runtime error: index out of range [0]` when attempting to update volume attachments on volumes that have no active attachments. This occurs when volumes are in intermediate states during detach operations, particularly after cluster/vm restarts. All volume provisioning becomes blocked, PVCs remain stuck in Pending state, and the cluster storage becomes unavailable.

This fix addresses the panic in `UpdateVolumeAttachment` when a volume has no active attachments by adding a `findVolumeAttachment` helper function that searches for attachments by instance ID, replacing unsafe direct slice access throughout the controller flow. `UpdateVolumeAttachment` now returns nil when there are no attachments to update, allowing detach operations to proceed without error. It refactors `ControllerPublishVolume` to use the helper function and add nil checks before dereferencing attachment slices, improving safety when checking if a volume is already attached to the requested node. It also adds an idempotency check to `ControllerUnpublishVolume` to return success if the volume is not attached to the requested node, per CSI spec.

