### PR TITLE
chart: support tolerations

### DIFF
--- a/charts/csi-hyperstack/templates/daemonset-node.yaml
+++ b/charts/csi-hyperstack/templates/daemonset-node.yaml
@@ -21,6 +21,10 @@ spec:
       {{- end }}
       serviceAccountName: csi-hyperstack-node-sa
       hostNetwork: true
+      {{- if .Values.node.tolerations }}
+      tolerations:
+        {{- toYaml .Values.node.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: csi-hyperstack-node
           image: {{ .Values.components.csiHyperstack.image }}:{{ .Values.components.csiHyperstack.tag | default .Chart.AppVersion }}

--- a/charts/csi-hyperstack/templates/deployment-controller.yaml
+++ b/charts/csi-hyperstack/templates/deployment-controller.yaml
@@ -21,6 +21,10 @@ spec:
         - name: {{ .Values.imagePullSecrets }}
       {{- end }}
       serviceAccountName: csi-hyperstack-controller-sa
+      {{- if .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml .Values.controller.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: csi-hyperstack
           image: {{ .Values.components.csiHyperstack.image }}:{{ .Values.components.csiHyperstack.tag | default .Chart.AppVersion }}

--- a/charts/csi-hyperstack/values.yaml
+++ b/charts/csi-hyperstack/values.yaml
@@ -17,7 +17,16 @@ components:
     image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
 
 hyperstack:
+  apiKey: ~
   apiAddress: "https://infrahub-api.nexgencloud.com/v1"
+
+node:
+  tolerations:
+    - operator: Exists
+      effect: NoSchedule
+
+controller:
+  tolerations: []
 
 storageClass:
   enabled: true

--- a/charts/csi-hyperstack/values.yaml
+++ b/charts/csi-hyperstack/values.yaml
@@ -23,7 +23,6 @@ hyperstack:
 node:
   tolerations:
     - operator: Exists
-      effect: NoSchedule
 
 controller:
   tolerations: []


### PR DESCRIPTION
This PR adds toleration support to the Helm chart.

Defaults:
  - Node DaemonSet: tolerates all `NoSchedule` taints, ensuring it runs on all nodes including those with custom taints
  - Controller Deployment: no tolerations by default; can be customized via Helm values